### PR TITLE
Allow working with arbitrary heap indexes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beap"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["starovoid"]
 license = "MIT"
 edition = "2021"

--- a/src/core.rs
+++ b/src/core.rs
@@ -147,7 +147,7 @@ impl<T: Ord> Beap<T> {
     pub fn remove(&mut self, val: &T) -> bool {
         match self.index(val) {
             Some(idx) => {
-                self.remove_from_pos(idx);
+                self.remove_index(idx);
                 true
             }
             None => false,
@@ -331,7 +331,7 @@ impl<T: Ord> Beap<T> {
             let idx = ((start - empty)..=(end - empty))
                 .min_by_key(|&i| &self.data[i])
                 .unwrap();
-            self.remove_from_pos(idx)
+            self.remove_index(idx)
         })
     }
 
@@ -457,19 +457,19 @@ impl<T: Ord> Beap<T> {
     /// # Algorithm
     ///
     /// Let there be `Beap`
-    /// ```
-    /// //         9
-    /// //       8   7
-    /// //     6   5   4
-    /// //   3   2   1   0
+    /// ```text
+    ///          9
+    ///        8   7
+    ///      6   5   4
+    ///    3   2   1   0
     /// ```
     ///
     /// Consider it as the upper left corner of the matrix:
-    /// ```
-    /// //   9 7 4 0
-    /// //   8 5 1
-    /// //   6 2
-    /// //   3
+    /// ```text
+    ///    9 7 4 0
+    ///    8 5 1
+    ///    6 2
+    ///    3
     /// ```
     ///
     /// Let's start the search from the upper-right corner
@@ -549,8 +549,34 @@ impl<T: Ord> Beap<T> {
         }
     }
 
-    // Removing an item in the specified position.
-    pub(crate) fn remove_from_pos(&mut self, pos: usize) -> Option<T> {
+    /// Remove an element at the specified position.
+    ///
+    /// If the passed index is greater than the max index of the beap, it returns `None`.
+    ///
+    /// # Time complexity
+    ///
+    /// *O*(sqrt(*2n*))
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use beap::Beap;
+    ///
+    /// let mut b = Beap::from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    /// assert_eq!(b.remove_index(7), Some(2));
+    /// assert_eq!(b.remove_index(0), Some(9));
+    ///
+    /// let idx4 = b.index(&4).unwrap();
+    /// assert_eq!(b.remove_index(idx4), Some(4));
+    ///
+    /// assert_eq!(b.remove_index(100), None);
+    ///
+    /// ```
+    pub fn remove_index(&mut self, pos: usize) -> Option<T> {
+        if pos > self.data.len() {
+            return None;
+        }
+
         self.data.pop().map(|mut item| {
             if !self.is_empty() {
                 if let Some((start, _)) = self.span(self.height) {

--- a/src/core.rs
+++ b/src/core.rs
@@ -449,20 +449,28 @@ impl<T: Ord> Beap<T> {
         }
     }
 
-    /// Given the val value, find the index of an element with such a value
-    /// or return None if such an element does not exist.
-    /// Time complexity: O(sqrt(2n)).
+    /// Find the index of an element with given value
+    /// or return `None` if such element does not exist.
     ///
-    /// Let there be Beap        9
-    ///                        8   7
-    ///                      6   5   4
-    ///                    3   2   1   0
+    /// Time complexity: *O(sqrt(2n))*.
+    ///
+    /// # Algorithm
+    ///
+    /// Let there be `Beap`
+    /// ```
+    /// //         9
+    /// //       8   7
+    /// //     6   5   4
+    /// //   3   2   1   0
+    /// ```
     ///
     /// Consider it as the upper left corner of the matrix:
-    /// 9 7 4 0
-    /// 8 5 1
-    /// 6 2
-    /// 3
+    /// ```
+    /// //   9 7 4 0
+    /// //   8 5 1
+    /// //   6 2
+    /// //   3
+    /// ```
     ///
     /// Let's start the search from the upper-right corner
     /// (the last element of the inner vector).
@@ -479,7 +487,19 @@ impl<T: Ord> Beap<T> {
     /// 4) As soon as we find an element with equal val priority, we return its index,
     ///     and if we find ourselves in the left in the lower corner and the value in it
     ///     is not equal to val, so the desired element does not exist and it's time to return None.
-    fn index(&self, val: &T) -> Option<usize> {
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use beap::Beap;
+    ///
+    /// let b = Beap::<i32>::from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    /// assert_eq!(b.index(&9), Some(0));
+    /// assert_eq!(b.index(&4), Some(5));
+    /// assert_eq!(b.index(&1), Some(8));
+    /// assert_eq!(b.index(&999), None);
+    /// ```
+    pub fn index(&self, val: &T) -> Option<usize> {
         let (left_low, mut right_up) = match self.span(self.height) {
             Some(idxs) => idxs,
             None => return None, // Beap is empty.

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,4 +1,6 @@
 //! Beap logic.
+use crate::PosMut;
+
 use super::{Beap, PeekMut, TailMut};
 
 impl<T: Ord> Beap<T> {
@@ -301,6 +303,50 @@ impl<T: Ord> Beap<T> {
                 beap: self,
                 sift: false,
                 pos: idx,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Returns a mutable reference to the item with given position, or
+    /// `None` if the position is out of bounds.
+    ///
+    /// Note: If the `PosMut` value is leaked, the beap may be in an
+    /// inconsistent state.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use beap::Beap;
+    /// let mut beap = Beap::new();
+    /// assert!(beap.get_mut(0).is_none());
+    ///
+    /// beap.push(1);
+    /// beap.push(5);
+    /// beap.push(2);
+    /// beap.push(3);
+    /// beap.push(0);
+    /// {
+    ///     let mut val = beap.get_mut(3).unwrap();
+    ///     assert_eq!(*val, 1);
+    ///     *val = 10;
+    /// }
+    /// assert_eq!(beap.peek(), Some(&10));
+    /// assert!(beap.get_mut(100).is_none());
+    /// ```
+    ///
+    /// # Time complexity
+    ///
+    /// *O*(sqrt(*2n*)),
+    pub fn get_mut(&mut self, pos: usize) -> Option<PosMut<'_, T>> {
+        if pos < self.data.len() {
+            Some(PosMut {
+                beap: self,
+                sift: false,
+                pos,
             })
         } else {
             None

--- a/src/core.rs
+++ b/src/core.rs
@@ -681,6 +681,28 @@ impl<T> Beap<T> {
         self.data.first()
     }
 
+    /// Get an item at the specified position.
+    ///
+    /// Returns `None` if the `pos` goes beyond the beap.
+    ///
+    /// # Time complexity
+    ///
+    /// Cost is *O*(1) in the worst case.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use beap::Beap;
+    ///
+    /// let b = Beap::from([1, 3, 2, 4]);
+    /// assert_eq!(b.get(0), Some(&4));
+    /// assert_eq!(b.get(3), Some(&1));
+    /// assert_eq!(b.get(100), None);
+    /// ```
+    pub fn get(&self, pos: usize) -> Option<&T> {
+        self.data.get(pos)
+    }
+
     /// Start and end indexes of block b.
     /// Returns `None` if the block is empty.
     pub(crate) fn span(&self, b: usize) -> Option<(usize, usize)> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ impl<T: Ord> DerefMut for TailMut<'_, T> {
 impl<'a, T: Ord> TailMut<'a, T> {
     /// Removes the peeked value from the beap and returns it.
     pub fn pop(mut this: TailMut<'a, T>) -> T {
-        let value = this.beap.remove_from_pos(this.pos).unwrap();
+        let value = this.beap.remove_index(this.pos).unwrap();
         this.sift = false;
         value
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,5 +243,56 @@ impl<'a, T: Ord> TailMut<'a, T> {
     }
 }
 
+/// Structure wrapping a mutable reference to the item with provided index on a `Beap`.
+///
+/// This `struct` is created by the [`get_mut`] method on [`Beap`]. See
+/// its documentation for more.
+///
+/// [`get_mut`]: Beap::get_mut
+pub struct PosMut<'a, T: 'a + Ord> {
+    beap: &'a mut Beap<T>,
+    sift: bool,
+    pos: usize,
+}
+
+impl<T: Ord + fmt::Debug> fmt::Debug for PosMut<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PosMut")
+            .field(&self.beap.data[self.pos])
+            .finish()
+    }
+}
+
+impl<T: Ord> Drop for PosMut<'_, T> {
+    fn drop(&mut self) {
+        if self.sift {
+            self.beap.repair(self.pos);
+        }
+    }
+}
+
+impl<T: Ord> Deref for PosMut<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.beap.data.get(self.pos).unwrap()
+    }
+}
+
+impl<T: Ord> DerefMut for PosMut<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.sift = true;
+        self.beap.data.get_mut(self.pos).unwrap()
+    }
+}
+
+impl<'a, T: Ord> PosMut<'a, T> {
+    /// Removes the borrowed value from the beap and returns it.
+    pub fn remove(mut this: PosMut<'a, T>) -> T {
+        let value = this.beap.remove_index(this.pos).unwrap();
+        this.sift = true;
+        value
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1133,3 +1133,18 @@ fn test_try_reserve_exact() {
     assert!(b.try_reserve_exact(50).is_ok());
     assert!(b.capacity() >= 53);
 }
+
+#[test]
+fn test_index() {
+    let mut b = Beap::<i32>::new();
+    assert_eq!(b.index(&42), None);
+    b.push(42);
+    assert_eq!(b.index(&42), Some(0));
+    b.extend([1, 2, 3]);
+    assert_eq!(b.index(&42), Some(0));
+    assert_eq!(b.index(&1), Some(3));
+    b.push(100);
+    assert_eq!(b.index(&1), Some(3));
+    assert_eq!(b.index(&2), Some(4));
+    assert_eq!(b.index(&42), Some(2));
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1148,3 +1148,14 @@ fn test_index() {
     assert_eq!(b.index(&2), Some(4));
     assert_eq!(b.index(&42), Some(2));
 }
+
+#[test]
+fn test_remove_from_pos() {
+    let mut b = Beap::from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+    assert_eq!(b.remove_index(8), Some(1));
+    let idx4 = b.index(&4).unwrap();
+    assert_eq!(b.remove_index(idx4), Some(4));
+    assert_eq!(b.remove_index(100), None);
+    assert_eq!(b.remove_index(0), Some(9));
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{Beap, PeekMut, TailMut};
+use crate::{Beap, PeekMut, PosMut, TailMut};
 use rand::{thread_rng, Rng};
 use std::cmp::Reverse;
 use std::collections::binary_heap;
@@ -1158,4 +1158,41 @@ fn test_remove_from_pos() {
     assert_eq!(b.remove_index(idx4), Some(4));
     assert_eq!(b.remove_index(100), None);
     assert_eq!(b.remove_index(0), Some(9));
+}
+
+#[test]
+fn test_get_mut() {
+    let mut beap: Beap<i32> = Beap::new();
+    assert!(beap.get_mut(0).is_none());
+
+    beap.push(3);
+    {
+        let mut top = beap.get_mut(0).unwrap();
+        *top = 4;
+    }
+    assert_eq!(beap.get(0), Some(&4));
+
+    beap.push(1);
+    beap.push(6);
+    assert_eq!(beap.get(1), Some(&1));
+    {
+        let mut x = beap.get_mut(1).unwrap();
+        *x = 0;
+    }
+    assert_eq!(beap.get(1), Some(&0));
+
+    {
+        let mut x = beap.get_mut(1).unwrap();
+        *x = 10;
+    }
+    assert_eq!(beap.peek(), Some(&10));
+    assert_eq!(beap.get(1), Some(&6));
+
+    println!("{:?}", beap.clone().into_vec());
+    {
+        let pos = beap.get_mut(1).unwrap();
+        println!("{:?}", pos);
+        assert_eq!(PosMut::remove(pos), 6);
+    }
+    assert_eq!(beap.tail(), Some(&4));
 }


### PR DESCRIPTION
Added the ability to find the index of an element in `Beep` using the `Beap::index`  and work with it using the `Beap::get`, `Beap::get_mut`, `Beap::remove_index` methods. As suggested in issue #2.